### PR TITLE
Fix an issue with empty collection for cy.nodes()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,10 @@ class CytoscapeDomNode {
             this._add_node(ev.target);
         });
 
-        for (let n of cy.nodes())
-            this._add_node(n);
+        if (cy.nodes().length){
+            for (let n of cy.nodes())
+                this._add_node(n);
+        }
 
         cy.on("pan zoom", (ev) => {
             let pan  = cy.pan();


### PR DESCRIPTION
We found an issue when creating a new CytoscapeDomNode
If cy.nodes() is empty, the loop is unable to execute.